### PR TITLE
feat: 모임 삭제 기능 구현

### DIFF
--- a/src/main/java/com/backend/controller/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/controller/global/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.backend.controller.global;
 
 import com.backend.dto.bases.ErrorResponse;
+import com.backend.exception.AccessDeniedException;
 import com.backend.exception.AlreadyExistsException;
 import com.backend.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
@@ -24,6 +25,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAlreadyExistException(AlreadyExistsException exception) {
         ErrorResponse errorResponse = new ErrorResponse(exception.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException exception) {
+        ErrorResponse errorResponse = new ErrorResponse(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 }
 

--- a/src/main/java/com/backend/controller/meeting/MeetingController.java
+++ b/src/main/java/com/backend/controller/meeting/MeetingController.java
@@ -12,6 +12,8 @@ import com.backend.service.meeting.MeetingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity.BodyBuilder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,6 +50,13 @@ public class MeetingController {
     public ResponseEntity<MeetingDetailResponse> getMeeting(@PathVariable Long meetingId, @CurrentMember User user) {
         MeetingDetailResponse meeting = meetingService.readOneMeeting(meetingId, user);
         return ResponseEntity.ok(meeting);
+    }
+
+    @CheckUserNotNull
+    @DeleteMapping("/{meetingId}")
+    public ResponseEntity<Void> deleteMeeting(@PathVariable Long meetingId, @CurrentMember User user) {
+        meetingService.deleteMeeting(meetingId, user);
+        return ResponseEntity.noContent().build();
     }
 
     @CheckUserNotNull

--- a/src/main/java/com/backend/entity/meeting/Meeting.java
+++ b/src/main/java/com/backend/entity/meeting/Meeting.java
@@ -4,6 +4,7 @@ import com.backend.entity.base.BaseEntity;
 import com.backend.entity.meeting.embeddable.MeetingAddress;
 import com.backend.entity.meeting.embeddable.MeetingTime;
 import com.backend.entity.user.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -58,14 +59,14 @@ public class Meeting extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User host;
 
-    @OneToMany(mappedBy = "meeting")
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MeetingImage> meetingImages;
 
-    @OneToMany(mappedBy = "meeting")
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<MeetingHashtag> meetingHashtags;
 
     @Builder.Default
-    @OneToMany(mappedBy = "meeting")
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MeetingRegistration> registrations = new ArrayList<>();
 
     @Transient

--- a/src/main/java/com/backend/exception/AccessDeniedException.java
+++ b/src/main/java/com/backend/exception/AccessDeniedException.java
@@ -1,0 +1,7 @@
+package com.backend.exception;
+
+public class AccessDeniedException extends RuntimeException{
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/backend/exception/ErrorMessages.java
+++ b/src/main/java/com/backend/exception/ErrorMessages.java
@@ -8,5 +8,6 @@ public class ErrorMessages {
     public static final String INVALID_PAYLOAD = "페이로드가 올바르지 않습니다.";
     public static final String NO_MATCH_TOKEN_AND_USER = "해당 토큰과 맞는 사용자가 존재하지 않습니다!";
     public static final String NOT_EXIST_USER = "로그인 후 진행해주셔야 합니다!";
+    public static final String ACCESS_DENIED = "권한이 없습니다!";
 }
 

--- a/src/main/java/com/backend/repository/meeting/MeetingRepository.java
+++ b/src/main/java/com/backend/repository/meeting/MeetingRepository.java
@@ -1,8 +1,13 @@
 package com.backend.repository.meeting;
 
 import com.backend.entity.meeting.Meeting;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long>, MeetingRepositoryCustom {
+    @Query("SELECT m.host.id FROM Meeting m WHERE m.id = :meetingId")
+    Optional<Long> findOwnerIdByMeetingId(@Param("meetingId") Long meetingId);
 }
 

--- a/src/main/java/com/backend/repository/meeting/MeetingRepositoryCustom.java
+++ b/src/main/java/com/backend/repository/meeting/MeetingRepositoryCustom.java
@@ -13,5 +13,7 @@ public interface MeetingRepositoryCustom {
     Optional<Meeting> findMeetingWithDetailsById(Long id);
 
     List<Meeting> findAllByHost(User host);
+
+    void deleteMeetingWithAllDetails(Long meetingId);
 }
 

--- a/src/main/java/com/backend/repository/meeting/MeetingRepositoryImpl.java
+++ b/src/main/java/com/backend/repository/meeting/MeetingRepositoryImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -62,6 +63,25 @@ public class MeetingRepositoryImpl implements MeetingRepositoryCustom {
         return query.fetch().stream()
                 .map(this::enrichMeetingWithHashtags)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void deleteMeetingWithAllDetails(Long meetingId) {
+        queryFactory.delete(QMeetingImage.meetingImage)
+                .where(QMeetingImage.meetingImage.meeting.id.eq(meetingId))
+                .execute();
+        queryFactory.delete(QMeetingHashtag.meetingHashtag)
+                .where(QMeetingHashtag.meetingHashtag.meeting.id.eq(meetingId))
+                .execute();
+        queryFactory.delete(QMeetingRegistration.meetingRegistration)
+                .where(QMeetingRegistration.meetingRegistration.meeting.id.eq(meetingId))
+                .execute();
+
+        // 마지막으로 Meeting 엔티티 삭제
+        queryFactory.delete(QMeeting.meeting)
+                .where(QMeeting.meeting.id.eq(meetingId))
+                .execute();
     }
 
     private JPAQuery<Meeting> createBaseMeetingQuery() {


### PR DESCRIPTION
- 3개의 관계 테이블에 대해서도 삭제가 진행되어야함.
- orphanRemoval = true옵션은 불필요한 조회가 많이 일어나는 것으로 판단
- 따라서 querydsl로 meetingId에 따라 순차적으로 관계테이블을 삭제 후 meeting을 삭제하도록 구현