### PR TITLE
fix: 모임 삭제시 채팅 관련된 정보도 삭제하도록 변경

### DIFF
--- a/src/main/java/com/backend/controller/meeting/MeetingController.java
+++ b/src/main/java/com/backend/controller/meeting/MeetingController.java
@@ -76,5 +76,3 @@ public class MeetingController {
         return ResponseEntity.ok(meetings);
     }
 }
-
-


### PR DESCRIPTION
- cascade, querydsl, db레벨에서의 고려를 전체적으로 따졌을 때, 이미 querydsl로 삭제를 구현했기에, 모임 삭제는 querydsl로 고려